### PR TITLE
docs: rewrite README as concise visual walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,162 +1,73 @@
-# WordPress to Sanity Migrator
+# 🚚 WordPress → Sanity Migrator
 
-A visual interface for migrating content from WordPress to Sanity CMS. This application streamlines
-the migration process with database extraction, media processing, content transformation, and visual
-verification.
+A visual, 4-step dashboard for migrating WordPress content into Sanity. From SQL dump to live import — without the headaches.
 
-## Features
+---
 
-- **Docker Container Management**: Start/stop WordPress database container with ingested backup
-  through the UI
-- **Database Extraction**: Connect to WordPress MySQL databases and extract posts, pages, and media
-- **Content Transformation**: Automatically convert WordPress content to Sanity-compatible format
-- **Media Processing**: Track and map media references with support for images, audio, and video
-- **Visual Verification**: Review, search, filter, and export migrated content before final import
-- **Tag Analysis**: Identify and analyze HTML tags and media references in content
+## ✨ Features
 
-## Installation
+- 🐳 **Docker Management** — spin up MariaDB and import your SQL dump in one click
+- 🔄 **Prepare Migration** — extract posts, pages and media into Sanity-ready JSON
+- 🔍 **Verify Migration** — search, filter and preview every transformed post
+- 🚀 **Import to Sanity** — test run a single post, then ship the whole dataset
+
+---
+
+## 🛠️ Quick Start
 
 ```bash
-# Clone the repository
-git clone https://github.com/webbertakken/wordpress-to-sanity-migrator.git
-cd wordpress-to-sanity-migrator
-
-# Install dependencies (use Yarn)
 yarn install
-
-# Start development server
 yarn dev
 ```
 
-## Usage
+Drop your data into `/input`:
 
-### 1. Prepare Your WordPress Data
+- `input/backup.sql` — WordPress database dump
+- `input/uploads/` — media files (keep WordPress year/month structure)
 
-Place your WordPress data in the `/input` directory:
-
-- Database backup: `/input/backup.sql`
-- Media files: `/input/uploads/` (maintain WordPress year/month structure)
-
-### 2. Start Docker Container
-
-Use the Docker Manager UI to start a MySQL container:
-
-- Navigate to the Docker Management section
-- Click "Start Container" to run WordPress database on localhost:3306
-
-### 3. Run Migration
-
-1. **Prepare Migration**: Extract and transform WordPress content
-   - Connects to the database
-   - Processes posts, pages, and media references
-   - Outputs to `/input/sanity-migration.json`
-
-2. **Verify Migration**: Review the migrated content
-   - Search and filter posts
-   - Check media reference integrity
-   - Export selected content
-
-### 4. Import to Sanity
-
-Use the generated `sanity-migration.json` file with Sanity's import tools to complete the migration.
-
-## Project Structure
+Set Sanity credentials in `.env.local`:
 
 ```
-wordpress-to-sanity-migrator/
-├── src/
-│   ├── app/           # Next.js app router pages
-│   │   └── api/       # Server-side API routes
-│   ├── components/    # React components
-│   ├── domain/        # Business logic (DDD)
-│   ├── types/         # TypeScript definitions
-│   └── utils/         # Utility functions
-├── input/             # Migration data directory
-│   ├── uploads/       # WordPress media files
-│   └── *.sql          # Database backups
-└── public/            # Static assets
+NEXT_PUBLIC_SANITY_PROJECT_ID=...
+NEXT_PUBLIC_SANITY_DATASET=...
+SANITY_API_WRITE_TOKEN=...
+SANITY_API_VERSION=...
 ```
 
-## Development
+---
+
+## 📋 The 4 Steps
+
+### 1️⃣ Spin up the database from your SQL dump
+
+![Docker Management](docs/01-database-from-sql-dump.png)
+
+### 2️⃣ Prepare the migration
+
+![Prepare Migration](docs/02-migration-options.png)
+
+### 3️⃣ Verify every post before it ships
+
+![Verify Migration](docs/03-verify-migration.png)
+
+### 4️⃣ Test import a single post, then go for real
+
+![Test Import](docs/04-import-test-run.png)
+![Full Import](docs/05-import-for-real.png)
+
+---
+
+## 🧪 Development
 
 ```bash
-# Development server with Turbopack
-yarn dev
-
-# Run tests
-yarn test
-yarn test:watch    # Watch mode
-yarn test:ui       # UI mode
-yarn test:coverage # Coverage report
-
-# Linting
-yarn lint
-
-# Build for production
-yarn build
-yarn start
+yarn dev            # dev server (Turbopack)
+yarn test           # run tests
+yarn lint           # lint
+yarn build          # production build
 ```
 
-## Configuration
+---
 
-The application expects a WordPress MySQL database with these default settings:
+## 📄 License
 
-- Host: `localhost`
-- Port: `3306`
-- Database: `mydatabase`
-- User: `root`
-- Password: `rootpassword`
-
-These can be modified in the Docker container configuration.
-
-## Architecture
-
-WordPress to Sanity Migrator follows Domain-Driven Design principles:
-
-- **Frontend Layer**: React components for UI (`/src/components/`)
-- **API Layer**: Next.js API routes for server operations (`/src/app/api/`)
-- **Domain Layer**: Core business logic (`/src/domain/`)
-- **Infrastructure**: Database connections, file system operations
-
-### Key Components
-
-- `DockerManagerUI`: Container lifecycle management
-- `PrepareMigrationUI`: Content extraction and transformation
-- `VerifyMigrationUI`: Migration review and export
-- `MediaProcessor`: Media reference extraction and mapping
-- `TagAnalyzer`: HTML content analysis
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-### Development Guidelines
-
-- Use Yarn for package management (not npm)
-- Follow Domain-Driven Design principles
-- Write tests for business logic
-- Ensure all code passes linting before commits
-- Use conventional commit messages
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-Built with:
-
-- [Next.js 15](https://nextjs.org/) - React framework
-- [TypeScript](https://www.typescriptlang.org/) - Type safety
-- [Tailwind CSS](https://tailwindcss.com/) - Styling
-- [Vitest](https://vitest.dev/) - Testing framework
-- [Docker](https://www.docker.com/) - Container management
-
-## Support
-
-For issues, questions, or contributions, please use the
-[GitHub Issues](https://github.com/webbertakken/wordpress-to-sanity-migrator/issues) page.
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Replaces the verbose README with a short, image-driven 4-step guide that mirrors the migration dashboard tabs (Docker → Prepare → Verify → Import).

### Changes
- Trimmed ~130 lines of boilerplate (architecture diagrams, contributing rituals, acknowledgments wall)
- Added screenshots from `docs/` for each of the 4 migration steps
- Kept Quick Start, env vars, and dev commands

### Preview
See `README.md` on this branch.

_Diff: `+42 / -131` in a single file._