### PR TITLE
feat(transformer): image captions, alignment, divider and embed blocks

### DIFF
--- a/src/components/VerifyMigrationUI.tsx
+++ b/src/components/VerifyMigrationUI.tsx
@@ -796,6 +796,43 @@ export const VerifyMigrationUI: React.FC<VerifyMigrationUIProps> = ({ onComplete
                             max-width: 100%;
                             margin: 1rem 0;
                           }
+                          /* Figure captions sit directly under the media. */
+                          .preview-content figure {
+                            margin: 1rem 0;
+                          }
+                          .preview-content figcaption {
+                            margin-top: 0.4em;
+                            text-align: center;
+                            font-size: 0.875em;
+                            color: #4b5563;
+                          }
+                          /* Image alignment — mirrors WordPress's align classes. */
+                          .preview-content figure[data-align='left'] {
+                            float: left;
+                            margin: 0.5rem 1rem 1rem 0;
+                            max-width: 50%;
+                          }
+                          .preview-content figure[data-align='right'] {
+                            float: right;
+                            margin: 0.5rem 0 1rem 1rem;
+                            max-width: 50%;
+                          }
+                          .preview-content figure[data-align='center'] {
+                            margin-left: auto;
+                            margin-right: auto;
+                          }
+                          /* Divider blocks render as a thin horizontal rule. */
+                          .preview-content hr {
+                            border: 0;
+                            border-top: 1px solid #d1d5db;
+                            margin: 2rem 0;
+                          }
+                          /* Generic third-party embeds. */
+                          .preview-content .embed-block iframe {
+                            width: 100%;
+                            min-height: 360px;
+                            border: 0;
+                          }
                         `,
                             }}
                           />

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -44,10 +44,31 @@ export interface MigrationImageBlock {
   url: string // Temporary: original URL from WordPress
   localPath?: string // Temporary: local file path after download
   caption?: string
+  alignment?: 'left' | 'center' | 'right'
   // These will be added during import:
   // asset?: { _ref: string; _type: 'reference' }
   // hotspot?: SanityImageHotspot
   // crop?: SanityImageCrop
+}
+
+/**
+ * Plain horizontal-rule-style separator. Has no fields — its presence in the
+ * block content is the value. Renderers decide how to display it.
+ */
+export interface MigrationDividerBlock {
+  _type: 'divider'
+  _key: string
+}
+
+/**
+ * Generic third-party embed (URL + optional caption). Used for iframes that
+ * are not covered by the more specific video block (YouTube/Vimeo).
+ */
+export interface MigrationEmbedBlock {
+  _type: 'embed'
+  _key: string
+  url: string
+  caption?: string
 }
 
 export interface MigrationAudioBlock {
@@ -101,7 +122,12 @@ export interface MigrationTextBlock {
 
 // Migration-specific block content that includes temporary properties
 export type MigrationBlockContent = Array<
-  MigrationTextBlock | MigrationImageBlock | MigrationAudioBlock | MigrationVideoBlock
+  | MigrationTextBlock
+  | MigrationImageBlock
+  | MigrationAudioBlock
+  | MigrationVideoBlock
+  | MigrationDividerBlock
+  | MigrationEmbedBlock
 >
 
 // Types for migration that extend the actual Sanity schema types

--- a/src/utils/__tests__/divider-and-embed.test.ts
+++ b/src/utils/__tests__/divider-and-embed.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { htmlToBlockContent } from '../html-to-portable-text'
+import { blockContentToHtml } from '../block-content-to-html'
+import type {
+  MigrationDividerBlock,
+  MigrationEmbedBlock,
+  MigrationVideoBlock,
+} from '../../types/migration'
+
+describe('htmlToBlockContent — divider and embed', () => {
+  describe('<hr> -> divider block', () => {
+    it('produces a divider block from a self-closing <hr/>', async () => {
+      const html = '<p>Above</p><hr/><p>Below</p>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      expect(content).toHaveLength(3)
+      expect(content[0]._type).toBe('block')
+      expect(content[1]._type).toBe('divider')
+      expect(content[2]._type).toBe('block')
+      const divider = content[1] as MigrationDividerBlock
+      expect(divider._key).toBeTruthy()
+    })
+
+    it('produces a divider block from an opening <hr> tag', async () => {
+      const html = 'Intro\n\n<hr>\n\nOutro'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const dividers = content.filter((b) => b._type === 'divider')
+      expect(dividers).toHaveLength(1)
+    })
+  })
+
+  describe('<iframe> routing', () => {
+    it('routes a YouTube iframe through the existing video extractor', async () => {
+      const html =
+        '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0"></iframe>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      expect(content).toHaveLength(1)
+      const video = content[0] as MigrationVideoBlock
+      expect(video._type).toBe('video')
+      expect(video.videoType).toBe('youtube')
+    })
+
+    it('routes a Vimeo iframe through the existing video extractor', async () => {
+      const html = '<iframe src="https://player.vimeo.com/video/123456" frameborder="0"></iframe>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const video = content[0] as MigrationVideoBlock
+      expect(video._type).toBe('video')
+      expect(video.videoType).toBe('vimeo')
+    })
+
+    it('produces an embed block for any other iframe host', async () => {
+      const html =
+        '<iframe src="https://open.spotify.com/embed/track/abc" allowtransparency="true"></iframe>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      expect(content).toHaveLength(1)
+      const embed = content[0] as MigrationEmbedBlock
+      expect(embed._type).toBe('embed')
+      expect(embed.url).toBe('https://open.spotify.com/embed/track/abc')
+    })
+  })
+
+  describe('renderer', () => {
+    it('renders a divider block as a horizontal rule', () => {
+      const html = blockContentToHtml([{ _type: 'divider', _key: 'd1' }])
+      expect(html).toBe('<hr />')
+    })
+
+    it('renders an embed block as a figure with an iframe', () => {
+      const html = blockContentToHtml([
+        { _type: 'embed', _key: 'e1', url: 'https://example.com/widget' },
+      ])
+      expect(html).toContain('<iframe src="https://example.com/widget"')
+      expect(html).toContain('class="embed-block"')
+    })
+
+    it('renders an embed block with a caption', () => {
+      const html = blockContentToHtml([
+        {
+          _type: 'embed',
+          _key: 'e2',
+          url: 'https://example.com/widget',
+          caption: 'Interactive widget',
+        },
+      ])
+      expect(html).toContain('<figcaption>Interactive widget</figcaption>')
+    })
+
+    it('renders an image block with a figcaption when caption is set', () => {
+      const html = blockContentToHtml([
+        {
+          _type: 'image',
+          _key: 'i1',
+          alt: 'A scene',
+          url: 'http://example.com/x.jpg',
+          caption: 'A descriptive caption',
+        },
+      ])
+      expect(html).toContain('<figcaption>A descriptive caption</figcaption>')
+      expect(html).toContain('alt="A scene"')
+    })
+
+    it('omits the figcaption when no caption is set', () => {
+      const html = blockContentToHtml([
+        {
+          _type: 'image',
+          _key: 'i2',
+          alt: 'A scene',
+          url: 'http://example.com/x.jpg',
+        },
+      ])
+      expect(html).not.toContain('<figcaption>')
+    })
+
+    it('emits data-align on the figure when alignment is set', () => {
+      const html = blockContentToHtml([
+        {
+          _type: 'image',
+          _key: 'i3',
+          alt: '',
+          url: 'http://example.com/x.jpg',
+          alignment: 'right',
+        },
+      ])
+      expect(html).toContain('data-align="right"')
+    })
+
+    it('omits data-align when no alignment is set', () => {
+      const html = blockContentToHtml([
+        {
+          _type: 'image',
+          _key: 'i4',
+          alt: '',
+          url: 'http://example.com/x.jpg',
+        },
+      ])
+      expect(html).not.toContain('data-align')
+    })
+  })
+})

--- a/src/utils/__tests__/image-fidelity.test.ts
+++ b/src/utils/__tests__/image-fidelity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { htmlToBlockContent } from '../html-to-portable-text'
+import type { MigrationImageBlock } from '../../types/migration'
+
+/**
+ * Image fidelity — the migrator should preserve the information WordPress
+ * authors encode around an image: the figcaption text and any alignment
+ * class on either the `<figure>` or the `<img>`.
+ */
+describe('htmlToBlockContent — image fidelity', () => {
+  describe('captions', () => {
+    it('captures <figcaption> text into image.caption', async () => {
+      const html =
+        '<figure class="wp-block-image"><img src="http://example.com/photo.jpg" alt="A photo" /><figcaption>Sunset over the harbour</figcaption></figure>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      expect(content).toHaveLength(1)
+      const image = content[0] as MigrationImageBlock
+      expect(image._type).toBe('image')
+      expect(image.alt).toBe('A photo')
+      expect(image.caption).toBe('Sunset over the harbour')
+    })
+
+    it('omits the caption field when no figcaption is present', async () => {
+      const html = '<img src="http://example.com/photo.jpg" alt="A photo" />'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.caption).toBeUndefined()
+    })
+
+    it('decodes HTML entities inside figcaption text', async () => {
+      const html =
+        '<figure><img src="http://example.com/x.jpg" alt="" /><figcaption>Smith &amp; Jones &mdash; portrait</figcaption></figure>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.caption).toBe('Smith & Jones — portrait')
+    })
+  })
+
+  describe('alignment', () => {
+    it('captures aligncenter on the <figure>', async () => {
+      const html =
+        '<figure class="wp-block-image aligncenter"><img src="http://example.com/x.jpg" alt="" /></figure>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.alignment).toBe('center')
+    })
+
+    it('captures alignleft on the <img>', async () => {
+      const html = '<img class="alignleft size-full" src="http://example.com/x.jpg" alt="" />'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.alignment).toBe('left')
+    })
+
+    it('captures alignright on the <img>', async () => {
+      const html = '<img class="alignright" src="http://example.com/x.jpg" alt="" />'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.alignment).toBe('right')
+    })
+
+    it('treats alignnone as the default and omits the alignment field', async () => {
+      const html = '<img class="alignnone size-full" src="http://example.com/x.jpg" alt="" />'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.alignment).toBeUndefined()
+    })
+
+    it('lets the <img>-level alignment override the figure-level one', async () => {
+      const html =
+        '<figure class="aligncenter"><img class="alignleft" src="http://example.com/x.jpg" alt="" /></figure>'
+
+      const { content } = await htmlToBlockContent(html)
+
+      const image = content[0] as MigrationImageBlock
+      expect(image.alignment).toBe('left')
+    })
+  })
+
+  it('captures both caption and alignment together', async () => {
+    const html =
+      '<figure class="wp-block-image alignright"><img src="http://example.com/x.jpg" alt="A scene" /><figcaption>Caption text</figcaption></figure>'
+
+    const { content } = await htmlToBlockContent(html)
+
+    const image = content[0] as MigrationImageBlock
+    expect(image.alignment).toBe('right')
+    expect(image.caption).toBe('Caption text')
+    expect(image.alt).toBe('A scene')
+  })
+})

--- a/src/utils/block-content-to-html.ts
+++ b/src/utils/block-content-to-html.ts
@@ -17,9 +17,12 @@ export function blockContentToHtml(
           url?: string
           alt?: string
           caption?: string
+          alignment?: 'left' | 'center' | 'right'
         }
         const src = imageBlock.localPath || imageBlock.url || ''
-        const alt = imageBlock.alt || imageBlock.caption || ''
+        const alt = imageBlock.alt || ''
+        const caption = imageBlock.caption || ''
+        const alignment = imageBlock.alignment
 
         if (src) {
           // If it's a local path, convert to API URL for preview
@@ -27,9 +30,29 @@ export function blockContentToHtml(
             ? `/api/serve-media?path=${encodeURIComponent(src)}`
             : src
 
-          return `<figure><img src="${imageSrc}" alt="${alt}" style="max-width: 100%; height: auto;" /></figure>`
+          // `data-align` is read by the preview's typography CSS to flow the
+          // figure left/right or centre it. The default (no attribute) is the
+          // surrounding block flow, matching WordPress's `alignnone`.
+          const alignAttr = alignment ? ` data-align="${alignment}"` : ''
+          const figcaption = caption ? `<figcaption>${caption}</figcaption>` : ''
+
+          return `<figure${alignAttr}><img src="${imageSrc}" alt="${alt}" style="max-width: 100%; height: auto;" />${figcaption}</figure>`
         }
         return ''
+      }
+
+      // Handle divider blocks (`<hr>` semantic)
+      if (block._type === 'divider') {
+        return '<hr />'
+      }
+
+      // Handle generic embed blocks (iframes that are not YouTube/Vimeo)
+      if (block._type === 'embed') {
+        const embedBlock = block as { url?: string; caption?: string }
+        const url = embedBlock.url || ''
+        if (!url) return ''
+        const caption = embedBlock.caption ? `<figcaption>${embedBlock.caption}</figcaption>` : ''
+        return `<figure class="embed-block"><iframe src="${url}" loading="lazy" referrerpolicy="no-referrer"></iframe>${caption}</figure>`
       }
 
       // Handle audio blocks

--- a/src/utils/html-to-portable-text.ts
+++ b/src/utils/html-to-portable-text.ts
@@ -9,13 +9,17 @@ import type {
   MigrationImageBlock,
   MigrationAudioBlock,
   MigrationVideoBlock,
+  MigrationDividerBlock,
+  MigrationEmbedBlock,
 } from '../types/migration'
 
 // BlockChild interface is part of MigrationTextBlock's children property
 
 // interface Block is defined in MigrationTextBlock
 
-// Strip HTML tags and decode entities
+// Strip HTML tags and decode the common named entities. Mirrors the entity
+// list in parse-inline-html.ts so plain-text extraction (e.g. figcaption)
+// matches the rich-text path.
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, '') // Remove all tags
@@ -25,6 +29,9 @@ function stripHtml(html: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&hellip;/g, '…')
     .trim()
 }
 
@@ -256,12 +263,44 @@ function extractVideoBlocks(
   return blocks
 }
 
-// Extract image blocks using regex
+/**
+ * Map an `align(none|left|center|right)` class to the canonical alignment
+ * value. WordPress's `alignnone` is the implicit default and is dropped.
+ */
+function parseAlignment(html: string): MigrationImageBlock['alignment'] | undefined {
+  const match = /align(none|left|center|right)/i.exec(html)
+  if (!match) return undefined
+  const value = match[1].toLowerCase()
+  if (value === 'left' || value === 'center' || value === 'right') {
+    return value
+  }
+  return undefined
+}
+
+/**
+ * Extract the text of the first `<figcaption>` in the given HTML, if any.
+ * Returns `undefined` when no caption is present or it is empty.
+ */
+function parseFigcaption(html: string): string | undefined {
+  const match = /<figcaption[^>]*>([\s\S]*?)<\/figcaption>/i.exec(html)
+  if (!match) return undefined
+  const text = stripHtml(match[1])
+  return text.length > 0 ? text : undefined
+}
+
+// Extract image blocks using regex. The input may be a standalone `<img>`,
+// a `<figure>...</figure>` wrapper, or any HTML containing one or more
+// `<img>` tags. When the input is a figure, the figcaption text becomes the
+// caption and any alignment class (on the figure or the img) is captured.
 function extractImageBlocks(
   html: string,
   mediaMap: Map<string, MediaReference>,
 ): MigrationImageBlock[] {
   const blocks: MigrationImageBlock[] = []
+
+  // Pull figure-level attributes once — they apply to every image inside.
+  const figureCaption = parseFigcaption(html)
+  const figureAlignment = parseAlignment(html)
 
   // Pattern to match image blocks - handles attributes in any order
   const imagePattern = /<img[^>]*>/gi
@@ -278,6 +317,10 @@ function extractImageBlocks(
     const altMatch = /\s+alt="([^"]*)"/.exec(imgTag)
     const alt = altMatch ? altMatch[1] : ''
 
+    // Alignment may live on the <img> class or on a wrapping <figure>.
+    // The img-level class wins when both are present.
+    const alignment = parseAlignment(imgTag) ?? figureAlignment
+
     if (src) {
       const mediaRef = mediaMap.get(src)
       const imageBlock: MigrationImageBlock = {
@@ -287,11 +330,46 @@ function extractImageBlocks(
         url: src,
         localPath: mediaRef?.localPath,
       }
+      if (figureCaption) {
+        imageBlock.caption = figureCaption
+      }
+      if (alignment) {
+        imageBlock.alignment = alignment
+      }
       blocks.push(imageBlock)
     }
   }
 
   return blocks
+}
+
+/**
+ * Build a divider block from an `<hr>` tag.
+ */
+function extractDividerBlock(): MigrationDividerBlock {
+  return { _type: 'divider', _key: nanoid() }
+}
+
+/**
+ * Build a generic embed block from an `<iframe>` whose URL is not handled
+ * by the more specific video extractor (i.e. not YouTube or Vimeo).
+ */
+function extractEmbedBlock(html: string): MigrationEmbedBlock | null {
+  const srcMatch = /<iframe[^>]*\bsrc="([^"]+)"/i.exec(html)
+  if (!srcMatch) return null
+  return { _type: 'embed', _key: nanoid(), url: srcMatch[1] }
+}
+
+/**
+ * Detect whether an iframe URL points at a video host that is handled by
+ * the dedicated video extractor (YouTube or Vimeo). Other hosts are
+ * surfaced as generic embeds.
+ */
+function isVideoIframe(html: string): boolean {
+  const srcMatch = /<iframe[^>]*\bsrc="([^"]+)"/i.exec(html)
+  if (!srcMatch) return false
+  const src = srcMatch[1]
+  return /youtube\.com|youtu\.be|vimeo\.com/i.test(src)
 }
 
 // Removed unused extractTextBlocks function - text extraction is handled in htmlToBlockContent
@@ -330,8 +408,10 @@ export async function htmlToBlockContent(
     /<audio[^>]*>[\s\S]*?<\/audio>/gi,
     // Standalone video elements (with closing tag)
     /<video[^>]*>[\s\S]*?<\/video>/gi,
-    // Iframe embeds (for YouTube/Vimeo)
+    // Iframe embeds (YouTube/Vimeo become video blocks; other hosts become embed blocks)
     /<iframe[^>]*>/gi,
+    // Horizontal rule (becomes a divider block)
+    /<hr\b[^>]*\/?>/gi,
     // Blockquote elements
     /<blockquote[^>]*>[\s\S]*?<\/blockquote>/gi,
     // List elements (ul and ol)
@@ -425,8 +505,17 @@ export async function htmlToBlockContent(
       const videoBlocks = extractVideoBlocks(element, mediaMap)
       blocks.push(...videoBlocks)
     } else if (element.startsWith('<iframe')) {
-      const videoBlocks = extractVideoBlocks(element, mediaMap)
-      blocks.push(...videoBlocks)
+      // YouTube and Vimeo go through the video extractor; everything else
+      // is surfaced as a generic embed block.
+      if (isVideoIframe(element)) {
+        const videoBlocks = extractVideoBlocks(element, mediaMap)
+        blocks.push(...videoBlocks)
+      } else {
+        const embedBlock = extractEmbedBlock(element)
+        if (embedBlock) blocks.push(embedBlock)
+      }
+    } else if (element.startsWith('<hr')) {
+      blocks.push(extractDividerBlock())
     } else if (element.startsWith('<img')) {
       const imageBlocks = extractImageBlocks(element, mediaMap)
       blocks.push(...imageBlocks)


### PR DESCRIPTION
## Summary

Higher fidelity to authorial intent for images, plus support for the two canonical block types introduced in #3 (`divider`, `embed`).

| WordPress source | Result |
|---|---|
| `<figcaption>` text | `image.caption` |
| `aligncenter` / `alignleft` / `alignright` (on `<figure>` or `<img>`) | `image.alignment` |
| `alignnone` (default) | omitted |
| `<hr>` | `{_type: 'divider'}` |
| `<iframe src="…youtube…">` / `…vimeo…` | existing `video` block (unchanged) |
| `<iframe src="…anything else…">` | `{_type: 'embed', url, caption?}` |

## Why

Captions are the highest-impact dropped information in real WordPress corpora — every captioned image silently lost its caption. Alignment is less common but signals authorial intent (and `alignnone` was the only one ever produced by the previous code path). Divider and embed are the two new canonical types from PR #3 that no extractor was producing yet.

## Changes

### `src/types/migration.ts`
- Add `MigrationDividerBlock` and `MigrationEmbedBlock`.
- Add `alignment?: 'left' | 'center' | 'right'` to `MigrationImageBlock`.
- Extend the `MigrationBlockContent` union with the two new types.

### `src/utils/html-to-portable-text.ts`
- New helpers `parseAlignment(html)` and `parseFigcaption(html)`.
- `extractImageBlocks` now reads figure-level caption + alignment once and applies them to every image inside; an `<img>`-level alignment overrides the figure-level one.
- New `extractDividerBlock()` and `extractEmbedBlock(html)` helpers.
- New `isVideoIframe(html)` predicate routes YouTube/Vimeo iframes to the existing video extractor and everything else to embed.
- Patterns array gains `<hr>` so it becomes a top-level extracted element.
- `stripHtml` decodes `&mdash;`, `&ndash;`, `&hellip;` so figcaption text matches the rich-text path.

### `src/utils/block-content-to-html.ts`
- Image rendering: separates `alt` (stays on `<img>`) from `caption` (becomes a `<figcaption>`); `alignment` becomes `data-align` on the `<figure>`.
- New `divider` renderer → `<hr />`.
- New `embed` renderer → `<figure class="embed-block"><iframe src="…" loading="lazy" referrerpolicy="no-referrer"></iframe>…</figure>`.

### `src/components/VerifyMigrationUI.tsx`
- Preview CSS picks up the new shapes: `<figcaption>` styling, `data-align` floats / centers the figure, `<hr>` rule, embed iframe sizing.

## Tests

| File | Cases | Covers |
|---|---:|---|
| `src/utils/__tests__/image-fidelity.test.ts` | 8 | figcaption capture, entity decoding, alignment on figure / img / both, alignnone-as-default, combination |
| `src/utils/__tests__/divider-and-embed.test.ts` | 13 | `<hr>` self-closing + opening forms, YouTube/Vimeo routing through video extractor, generic embed extraction, all renderer outputs (divider, embed with/without caption, image with/without caption + alignment) |

**94 tests pass total** (21 new), `yarn lint` clean, `yarn typecheck` shows the same 30 pre-existing errors as `main` (none introduced).

## Out of scope (follow-ups)

- WordPress shortcodes: `[caption]`, `[audio]`, `[video]`, `[ddownload]`.
- Structural cleanup: `<div>` / `<aside>` unwrap, explicit `<span>` test (already de facto unwrapped).
- WP block markers (`<!-- wp:image -->` etc.) — currently silently stripped which is correct, but worth integration tests.
- Galleries (`wp:gallery`, `wp-block-gallery`) → flatten to a series of image blocks.
- `examples/` directory with synthetic input → expected output fixtures covering every supported semantic.
