### PR TITLE
feat(import): autodetect Sanity prerequisites with live status checks

### DIFF
--- a/src/app/api/check-sanity-prerequisites/route.ts
+++ b/src/app/api/check-sanity-prerequisites/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@sanity/client'
+
+export interface PrerequisiteCheck {
+  id: 'projectId' | 'writeToken' | 'postSchema'
+  label: string
+  ok: boolean
+  detail?: string
+}
+
+export interface PrerequisitesResponse {
+  checks: PrerequisiteCheck[]
+  allOk: boolean
+}
+
+export async function GET() {
+  const checks: PrerequisiteCheck[] = []
+
+  const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+  const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
+  const token = process.env.SANITY_API_WRITE_TOKEN
+  const apiVersion = process.env.SANITY_API_VERSION || '2024-01-01'
+
+  // 1. NEXT_PUBLIC_SANITY_PROJECT_ID is set
+  checks.push({
+    id: 'projectId',
+    label: 'NEXT_PUBLIC_SANITY_PROJECT_ID is set',
+    ok: Boolean(projectId),
+    detail: projectId
+      ? `Project: ${projectId} · Dataset: ${dataset}`
+      : 'Environment variable is empty',
+  })
+
+  if (!projectId || !token) {
+    checks.push({
+      id: 'writeToken',
+      label: 'SANITY_API_WRITE_TOKEN with write permissions',
+      ok: false,
+      detail: !token ? 'Environment variable is empty' : 'Cannot verify without project ID',
+    })
+    checks.push({
+      id: 'postSchema',
+      label: "Sanity project has a 'post' schema",
+      ok: false,
+      detail: 'Cannot verify without project ID and write token',
+    })
+    return NextResponse.json({ checks, allOk: false } satisfies PrerequisitesResponse, {
+      headers: { 'Cache-Control': 'no-store' },
+    })
+  }
+
+  const client = createClient({ projectId, dataset, token, apiVersion, useCdn: false })
+
+  // 2. SANITY_API_WRITE_TOKEN with write permissions
+  // Verified by performing a dry-run mutation. Sanity returns auth errors before
+  // executing the (no-op) mutation, so this is a safe way to verify write access
+  // without touching the dataset.
+  let writeOk = false
+  let writeDetail = ''
+  try {
+    await client
+      .transaction()
+      .createOrReplace({
+        _id: 'drafts._prereq-check',
+        _type: 'post',
+        title: 'Prerequisite check (dry run)',
+      })
+      .commit({ dryRun: true, returnDocuments: false })
+    writeOk = true
+    writeDetail = 'Token accepted by Sanity (dry-run mutation succeeded)'
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    writeOk = false
+    writeDetail = `Token rejected: ${message}`
+  }
+  checks.push({
+    id: 'writeToken',
+    label: 'SANITY_API_WRITE_TOKEN with write permissions',
+    ok: writeOk,
+    detail: writeDetail,
+  })
+
+  // 3. Sanity project has a 'post' schema
+  // The Content Lake API is schemaless, so we can't ask "does the schema have a
+  // post type?" directly without studio-level auth. Instead we look at what's
+  // already in the dataset:
+  //   - 'post' documents exist  → schema in use, ✅
+  //   - dataset is empty        → can't verify, give benefit of the doubt, ✅
+  //   - other types but no post → likely missing post type, ❌
+  if (writeOk) {
+    try {
+      const [postCount, otherCount] = (await client.fetch(
+        '[count(*[_type == "post"]), count(*[!(_type match "sanity.*") && _type != "post"])]',
+      )) as [number, number]
+
+      if (postCount > 0) {
+        checks.push({
+          id: 'postSchema',
+          label: "Sanity project has a 'post' schema",
+          ok: true,
+          detail: `${postCount} existing 'post' document${postCount === 1 ? '' : 's'} in dataset`,
+        })
+      } else if (otherCount === 0) {
+        checks.push({
+          id: 'postSchema',
+          label: "Sanity project has a 'post' schema",
+          ok: true,
+          detail: 'Dataset is empty — schema will be verified on first import',
+        })
+      } else {
+        checks.push({
+          id: 'postSchema',
+          label: "Sanity project has a 'post' schema",
+          ok: false,
+          detail: `No 'post' documents found (dataset has ${otherCount} other document${otherCount === 1 ? '' : 's'}). Make sure the studio defines a 'post' type and is deployed.`,
+        })
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      checks.push({
+        id: 'postSchema',
+        label: "Sanity project has a 'post' schema",
+        ok: false,
+        detail: `Schema probe failed: ${message}`,
+      })
+    }
+  } else {
+    checks.push({
+      id: 'postSchema',
+      label: "Sanity project has a 'post' schema",
+      ok: false,
+      detail: 'Cannot verify without a working write token',
+    })
+  }
+
+  return NextResponse.json(
+    { checks, allOk: checks.every((c) => c.ok) } satisfies PrerequisitesResponse,
+    { headers: { 'Cache-Control': 'no-store' } },
+  )
+}

--- a/src/components/ImportToSanityUI.tsx
+++ b/src/components/ImportToSanityUI.tsx
@@ -20,6 +20,18 @@ interface PostOption {
   mediaTypes: string[]
 }
 
+interface PrerequisiteCheck {
+  id: 'projectId' | 'writeToken' | 'postSchema'
+  label: string
+  ok: boolean
+  detail?: string
+}
+
+interface PrerequisitesResponse {
+  checks: PrerequisiteCheck[]
+  allOk: boolean
+}
+
 interface ImportToSanityUIProps {
   onComplete?: () => void
 }
@@ -33,10 +45,37 @@ export const ImportToSanityUI: React.FC<ImportToSanityUIProps> = ({ onComplete }
   const [importMode, setImportMode] = useState<'single' | 'all'>('single')
   const [loadingPosts, setLoadingPosts] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [prereqs, setPrereqs] = useState<PrerequisitesResponse | null>(null)
+  const [prereqsLoading, setPrereqsLoading] = useState(true)
 
   useEffect(() => {
     loadAvailablePosts()
+    checkPrerequisites()
   }, [])
+
+  const checkPrerequisites = async () => {
+    try {
+      setPrereqsLoading(true)
+      const response = await fetch('/api/check-sanity-prerequisites')
+      const data = (await response.json()) as PrerequisitesResponse
+      setPrereqs(data)
+    } catch (error) {
+      console.error('Failed to check prerequisites:', error)
+      setPrereqs({
+        checks: [
+          {
+            id: 'projectId',
+            label: 'Failed to reach prerequisite check endpoint',
+            ok: false,
+            detail: error instanceof Error ? error.message : String(error),
+          },
+        ],
+        allOk: false,
+      })
+    } finally {
+      setPrereqsLoading(false)
+    }
+  }
 
   const loadAvailablePosts = async () => {
     try {
@@ -366,23 +405,73 @@ export const ImportToSanityUI: React.FC<ImportToSanityUIProps> = ({ onComplete }
         </div>
       </div>
 
-      {/* Environment Check */}
-      <div className="bg-yellow-900/30 border border-yellow-600/50 rounded-lg p-4 mb-6">
-        <h4 className="text-sm font-semibold text-yellow-300 mb-2">⚠️ Prerequisites</h4>
-        <ul className="text-sm text-yellow-200 space-y-1">
-          <li>• Set NEXT_PUBLIC_SANITY_PROJECT_ID in your environment</li>
-          <li>• Set SANITY_API_WRITE_TOKEN with write permissions</li>
-          <li>• Ensure your Sanity project has a &apos;post&apos; schema</li>
-        </ul>
-      </div>
+      {/* Prerequisites Check (auto-detected) */}
+      {(() => {
+        const allOk = prereqs?.allOk === true
+        const boxClass = prereqsLoading
+          ? 'bg-gray-800 border-gray-600/50'
+          : allOk
+            ? 'bg-green-900/30 border-green-600/50'
+            : 'bg-yellow-900/30 border-yellow-600/50'
+        const headingClass = prereqsLoading
+          ? 'text-gray-300'
+          : allOk
+            ? 'text-green-300'
+            : 'text-yellow-300'
+        const headingText = prereqsLoading
+          ? '⏳ Checking prerequisites…'
+          : allOk
+            ? '✅ All prerequisites met'
+            : '⚠️ Prerequisites'
+
+        return (
+          <div className={`${boxClass} border rounded-lg p-4 mb-6`}>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className={`text-sm font-semibold ${headingClass}`}>{headingText}</h4>
+              {!prereqsLoading && (
+                <button
+                  onClick={checkPrerequisites}
+                  className="text-xs text-gray-400 hover:text-gray-200 underline"
+                >
+                  Re-check
+                </button>
+              )}
+            </div>
+            <ul className="text-sm space-y-1">
+              {(prereqs?.checks ?? []).map((check) => (
+                <li key={check.id} className="flex items-start gap-2">
+                  <span
+                    className={`mt-0.5 flex-shrink-0 ${
+                      check.ok ? 'text-green-400' : 'text-red-400'
+                    }`}
+                    aria-label={check.ok ? 'pass' : 'fail'}
+                  >
+                    {check.ok ? '✅' : '❌'}
+                  </span>
+                  <div className="flex-1">
+                    <p className={check.ok ? 'text-green-200' : 'text-yellow-200'}>{check.label}</p>
+                    {check.detail && <p className="text-xs text-gray-400 mt-0.5">{check.detail}</p>}
+                  </div>
+                </li>
+              ))}
+              {prereqsLoading && !prereqs && (
+                <li className="text-gray-400">Detecting environment…</li>
+              )}
+            </ul>
+          </div>
+        )
+      })()}
 
       {/* Import Button */}
       <button
         onClick={startImport}
-        disabled={isImporting}
+        disabled={isImporting || prereqs?.allOk === false}
+        title={
+          prereqs?.allOk === false ? 'Resolve the prerequisites above before importing' : undefined
+        }
         className={`w-full py-3 px-6 rounded-lg font-medium transition-colors ${
-          isImporting
-            ? 'bg-gray-400 cursor-not-allowed text-white'
+          isImporting || prereqs?.allOk === false
+            ? 'bg-gray-500 cursor-not-allowed text-white opacity-60'
             : testMode
               ? 'bg-blue-600 hover:bg-blue-700 text-white'
               : 'bg-green-600 hover:bg-green-700 text-white'


### PR DESCRIPTION
Replaces the static "Prerequisites" warning box on the **Import to Sanity** step with live, autodetected checks.

## What it does

A new endpoint `GET /api/check-sanity-prerequisites` runs three checks:

| Check | How it's verified |
|---|---|
| `NEXT_PUBLIC_SANITY_PROJECT_ID` is set | env var presence |
| `SANITY_API_WRITE_TOKEN` with write permissions | dry-run `createOrReplace` mutation against Sanity (no data is touched) |
| Sanity project has a `post` schema | content heuristic: ✅ if `post` documents exist, ✅ if dataset is empty, ❌ if other docs exist but no `post` |

The UI:
- Shows ✅ / ❌ per check with a one-line detail (project ID, error message, doc counts, …)
- Turns the prerequisites box **green** when all pass, **amber** otherwise
- Disables the import button until all checks pass
- Has a **Re-check** link to re-run detection without reloading

## Why the schema check is a heuristic

The Content Lake API is schemaless and the `/schemas` REST endpoint requires a user-level token (`sanity.project/deployStudio` grant), which a project write token doesn't have. The content-based heuristic is the most reliable signal we can get with just the write token.

## Verified locally

- Valid token + dataset with 3 `post` documents → all green ✅
- Invalid token → write-permission check fails with the actual Sanity error message