### PR TITLE
chore: zero typecheck errors + husky pre-commit + GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs for the same ref when a new commit lands.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-gates:
+    name: Lint, format, typecheck, tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Pinned to match `volta.node` in package.json.
+          node-version: '22.16.0'
+
+      - name: Enable Corepack
+        # Activates the project-pinned Yarn version (packageManager field).
+        run: corepack enable
+
+      - name: Cache Yarn install
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            .yarn/install-state.gz
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Format check
+        run: yarn prettier --check .
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Tests
+        run: yarn test:run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Pre-commit hook
+#
+# Runs three things, fast first:
+# 1. lint-staged           — prettier + eslint --fix on changed files only
+# 2. yarn typecheck        — whole-project tsc --noEmit (fast incremental)
+# 3. yarn test:run         — full vitest suite (sub-second on this project)
+#
+# Together these are quick enough to run on every commit while catching the
+# vast majority of regressions before they ever reach CI.
+
+set -e
+
+yarn lint-staged
+yarn typecheck
+yarn test:run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🚚 WordPress → Sanity Migrator
 
-A visual, 4-step dashboard for migrating WordPress content into Sanity. From SQL dump to live import — without the headaches.
+A visual, 4-step dashboard for migrating WordPress content into Sanity. From SQL dump to live import
+— without the headaches.
 
 ---
 
@@ -52,8 +53,7 @@ SANITY_API_VERSION=...
 
 ### 4️⃣ Test import a single post, then go for real
 
-![Test Import](docs/04-import-test-run.png)
-![Full Import](docs/05-import-for-real.png)
+![Test Import](docs/04-import-test-run.png) ![Full Import](docs/05-import-for-real.png)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,17 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "prettier --write",
+      "eslint --fix --max-warnings=0"
+    ],
+    "*.{json,md,css,html,yml,yaml}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@sanity/client": "^7.6.0",
@@ -37,7 +47,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
     "eslint-plugin-prettier": "^5.5.0",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
+    "lint-staged": "^16.4.0",
     "mysql2": "^3.14.1",
     "node-html-parser": "^7.0.1",
     "prettier": "^3.6.2",

--- a/src/utils/__tests__/formatting-preservation.test.ts
+++ b/src/utils/__tests__/formatting-preservation.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { htmlToBlockContent } from '../html-to-portable-text'
 import { parseInlineHTML } from '../parse-inline-html'
+import type { MigrationBlockContent, MigrationTextBlock } from '../../types/migration'
+
+/**
+ * Narrow a block-content element to a text block. Throws when the element
+ * is not a text block so misshapen test expectations fail loudly with a
+ * useful message instead of with a TypeScript widening error.
+ */
+const asTextBlock = (block: MigrationBlockContent[number]): MigrationTextBlock => {
+  if (block._type !== 'block') {
+    throw new Error(`expected text block, got '${block._type}'`)
+  }
+  return block
+}
 
 describe('Formatting Preservation', () => {
   describe('parseInlineHTML', () => {
@@ -86,9 +99,8 @@ describe('Formatting Preservation', () => {
       const result = await htmlToBlockContent(html)
 
       expect(result.content).toHaveLength(1)
-      const block = result.content[0]
+      const block = asTextBlock(result.content[0])
 
-      expect(block._type).toBe('block')
       expect(block.children).toHaveLength(7) // Multiple spans for different formatting
 
       // Check that marks are preserved
@@ -107,13 +119,12 @@ describe('Formatting Preservation', () => {
       const result = await htmlToBlockContent(html)
 
       expect(result.content).toHaveLength(1)
-      expect(result.content[0]._type).toBe('block')
-      expect(result.content[0].style).toBe('blockquote')
+      const block = asTextBlock(result.content[0])
+      expect(block.style).toBe('blockquote')
 
       // Check that formatting is preserved within blockquote
-      const children = result.content[0].children
-      expect(children).toBeDefined()
-      const emphasisSpan = children?.find((child) => child.text === 'emphasis')
+      expect(block.children).toBeDefined()
+      const emphasisSpan = block.children?.find((child) => child.text === 'emphasis')
       expect(emphasisSpan?.marks).toEqual(['strong'])
     })
 
@@ -129,14 +140,15 @@ describe('Formatting Preservation', () => {
       expect(result.content).toHaveLength(2)
 
       // Check first list item
-      expect(result.content[0]._type).toBe('block')
-      expect(result.content[0].listItem).toBe('bullet')
-      const firstItemBold = result.content[0].children?.find((child) => child.text === 'bold')
+      const first = asTextBlock(result.content[0])
+      expect(first.listItem).toBe('bullet')
+      const firstItemBold = first.children?.find((child) => child.text === 'bold')
       expect(firstItemBold?.marks).toEqual(['strong'])
 
       // Check second list item
-      expect(result.content[1].listItem).toBe('bullet')
-      const secondItemItalic = result.content[1].children?.find((child) => child.text === 'italic')
+      const second = asTextBlock(result.content[1])
+      expect(second.listItem).toBe('bullet')
+      const secondItemItalic = second.children?.find((child) => child.text === 'italic')
       expect(secondItemItalic?.marks).toEqual(['em'])
     })
 
@@ -150,8 +162,8 @@ describe('Formatting Preservation', () => {
       const result = await htmlToBlockContent(html)
 
       expect(result.content).toHaveLength(2)
-      expect(result.content[0].listItem).toBe('number')
-      expect(result.content[1].listItem).toBe('number')
+      expect(asTextBlock(result.content[0]).listItem).toBe('number')
+      expect(asTextBlock(result.content[1]).listItem).toBe('number')
     })
 
     it('should preserve formatting in headings', async () => {
@@ -159,9 +171,10 @@ describe('Formatting Preservation', () => {
       const result = await htmlToBlockContent(html)
 
       expect(result.content).toHaveLength(1)
-      expect(result.content[0].style).toBe('h2')
+      const block = asTextBlock(result.content[0])
+      expect(block.style).toBe('h2')
 
-      const boldSpan = result.content[0].children?.find((child) => child.text === 'bold')
+      const boldSpan = block.children?.find((child) => child.text === 'bold')
       expect(boldSpan?.marks).toEqual(['strong'])
     })
 
@@ -179,13 +192,14 @@ describe('Formatting Preservation', () => {
       expect(result.content).toHaveLength(4)
 
       // Check different block types
-      expect(result.content[0].style).toBe('normal')
-      expect(result.content[1].style).toBe('blockquote')
-      expect(result.content[2].listItem).toBe('bullet')
-      expect(result.content[3].style).toBe('normal')
+      expect(asTextBlock(result.content[0]).style).toBe('normal')
+      expect(asTextBlock(result.content[1]).style).toBe('blockquote')
+      expect(asTextBlock(result.content[2]).listItem).toBe('bullet')
+      const last = asTextBlock(result.content[3])
+      expect(last.style).toBe('normal')
 
       // Check code formatting in last paragraph
-      const codeSpan = result.content[3].children?.find((child) => child.text === 'code')
+      const codeSpan = last.children?.find((child) => child.text === 'code')
       expect(codeSpan?.marks).toEqual(['code'])
     })
   })

--- a/src/utils/parse-inline-html.ts
+++ b/src/utils/parse-inline-html.ts
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid'
+import type { MigrationTextBlock } from '../types/migration'
 
 interface SpanNode {
   _type: 'span'
@@ -142,7 +143,7 @@ export function parseInlineHTML(html: string): ParsedInlineContent {
 export function createBlockWithInlineContent(
   html: string,
   style: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote' = 'normal',
-) {
+): MigrationTextBlock {
   const { children, markDefs } = parseInlineHTML(html)
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
+  dependencies:
+    environment: "npm:^1.0.0"
+  checksum: 10/189e23e75aacf00ee647ba0545687456cc4bc62547dd0cf6c7728f91fce88854c8e885d5819a278b39981bb846d9427693d2380c562aecdb0cf91d3342141e93
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -2085,6 +2094,13 @@ __metadata:
   version: 6.1.0
   resolution: "ansi-regex@npm:6.1.0"
   checksum: 10/495834a53b0856c02acd40446f7130cb0f8284f4a39afdab20d5dc42b2e198b1196119fe887beed8f9055c4ff2055e3b2f6d4641d0be018cdfb64fedf6fc1aac
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 10/9b17ce2c6daecc75bcd5966b9ad672c23b184dc3ed9bf3c98a0702f0d2f736c15c10d461913568f2cf527a5e64291c7473358885dd493305c84a1cfed66ba94f
   languageName: node
   linkType: hard
 
@@ -2101,6 +2117,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
   languageName: node
   linkType: hard
 
@@ -2469,6 +2492,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cli-cursor@npm:5.0.0"
+  dependencies:
+    restore-cursor: "npm:^5.0.0"
+  checksum: 10/1eb9a3f878b31addfe8d82c6d915ec2330cec8447ab1f117f4aa34f0137fbb3137ec3466e1c9a65bcb7557f6e486d343f2da57f253a2f668d691372dfa15c090
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "cli-truncate@npm:5.2.0"
+  dependencies:
+    slice-ansi: "npm:^8.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10/b789b6c2caff1560259aedeb6aaafcf41167d478df418d718a8c92edd6bc5a0ece272b8fb7e7911fbd31cef7b1ac8a30f2b21d90c3174b55a018fe3f2604a137
+  languageName: node
+  linkType: hard
+
 "client-only@npm:0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
@@ -2509,6 +2551,20 @@ __metadata:
     color-convert: "npm:^2.0.1"
     color-string: "npm:^1.9.0"
   checksum: 10/b23f5e500a79ea22428db43d1a70642d983405c0dd1f95ef59dbdb9ba66afbb4773b334fa0b75bb10b0552fd7534c6b28d4db0a8b528f91975976e70973c0152
+  languageName: node
+  linkType: hard
+
+"colorette@npm:^2.0.20":
+  version: 2.0.20
+  resolution: "colorette@npm:2.0.20"
+  checksum: 10/0b8de48bfa5d10afc160b8eaa2b9938f34a892530b2f7d7897e0458d9535a066e3998b49da9d21161c78225b272df19ae3a64d6df28b4c9734c0e55bbd02406f
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10/dfa9ebe2a433d277de5cb0252d23b10a543d245d892db858d23b516336a835c50fd4f52bee4cd13c705cc8acb6f03dc632c73dd806f7d06d3353eb09953dd17a
   languageName: node
   linkType: hard
 
@@ -2783,6 +2839,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.3.0":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10/98cc0b0e1daed1ed25afbf69dcb921fee00f712f51aab93aa1547e4e4e8171725cc4f0098aaa645b4f611a19da11ec9f4623eb6ff2b72314b39a8f2ae7c12bf2
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -2834,6 +2897,13 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: 10/dd3c1b9825e7f71f1e72b03c2344799ac73f2e9ef81b78ea8b373e55db021786c6b9f3858ea43a436a2c4611052670ec0afe85bc029c384cc71165feee2f4ba6
   languageName: node
   linkType: hard
 
@@ -3407,6 +3477,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: 10/54f5c8c543650d65f92d03dbef1bb73a682a920490c44699ad8f863a6b19bbca42fb7409aa09ca09cb98a44149d9a7bc1dffd55ca88a740bd928c7be0ad666a0
+  languageName: node
+  linkType: hard
+
 "eventsource@npm:2.0.2":
   version: 2.0.2
   resolution: "eventsource@npm:2.0.2"
@@ -3668,6 +3745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.1, get-east-asian-width@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "get-east-asian-width@npm:1.5.0"
+  checksum: 10/60bc34cd1e975055ab99f0f177e31bed3e516ff7cee9c536474383954a976abaa6b94a51d99ad158ef1e372790fa096cab7d07f166bb0778f6587954c0fbe946
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
@@ -3918,6 +4002,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10/c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -4102,6 +4195,15 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 10/44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-fullwidth-code-point@npm:5.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.1"
+  checksum: 10/4700d8a82cb71bd2a2955587b2823c36dc4660eadd4047bfbd070821ddbce8504fc5f9b28725567ecddf405b1e06c6692c9b719f65df6af9ec5262bc11393a6a
   languageName: node
   linkType: hard
 
@@ -4630,6 +4732,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lint-staged@npm:^16.4.0":
+  version: 16.4.0
+  resolution: "lint-staged@npm:16.4.0"
+  dependencies:
+    commander: "npm:^14.0.3"
+    listr2: "npm:^9.0.5"
+    picomatch: "npm:^4.0.3"
+    string-argv: "npm:^0.3.2"
+    tinyexec: "npm:^1.0.4"
+    yaml: "npm:^2.8.2"
+  bin:
+    lint-staged: bin/lint-staged.js
+  checksum: 10/eb7aa0d43e321bbf282ce0c693a3db762aa9b8e5bf29419a49c8877a247cd3a14cf8d519f914f8c8dcd2aea73ac83c0bb44fadb97a30004219e060a780dda74e
+  languageName: node
+  linkType: hard
+
+"listr2@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "listr2@npm:9.0.5"
+  dependencies:
+    cli-truncate: "npm:^5.0.0"
+    colorette: "npm:^2.0.20"
+    eventemitter3: "npm:^5.0.1"
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/b78ffd60443aed9a8e0fc9162eb941ea4d63210700d61a895eb29348f23fc668327e26bbca87a9e6a6208e7fa96c475fe1f1c6c19b46f376f547e0cba3b935ae
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^6.0.0":
   version: 6.0.0
   resolution: "locate-path@npm:6.0.0"
@@ -4643,6 +4775,19 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10/d0ea2dd0097e6201be083865d50c3fb54fbfbdb247d9cc5950e086c991f448b7ab0cdab0d57eacccb43473d3f2acd21e134db39f22dac2d6c9ba6bf26978e3d6
+  languageName: node
+  linkType: hard
+
+"log-update@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "log-update@npm:6.1.0"
+  dependencies:
+    ansi-escapes: "npm:^7.0.0"
+    cli-cursor: "npm:^5.0.0"
+    slice-ansi: "npm:^7.1.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/5abb4131e33b1e7f8416bb194fe17a3603d83e4657c5bf5bb81ce4187f3b00ea481643b85c3d5cefe6037a452cdcf7f1391ab8ea0d9c23e75d19589830ec4f11
   languageName: node
   linkType: hard
 
@@ -4777,6 +4922,13 @@ __metadata:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
   checksum: 10/6bf2a01672e7965eb9941d1f02044fad2bd12486b5553dc1116ff24c09a8723157601dc992e74c911d896175918448762df3b3fd0a6b61037dd1a9766ddfbf58
+  languageName: node
+  linkType: hard
+
+"mimic-function@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "mimic-function@npm:5.0.1"
+  checksum: 10/eb5893c99e902ccebbc267c6c6b83092966af84682957f79313311edb95e8bb5f39fb048d77132b700474d1c86d90ccc211e99bae0935447a4834eb4c882982c
   languageName: node
   linkType: hard
 
@@ -5185,6 +5337,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onetime@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "onetime@npm:7.0.0"
+  dependencies:
+    mimic-function: "npm:^5.0.0"
+  checksum: 10/eb08d2da9339819e2f9d52cab9caf2557d80e9af8c7d1ae86e1a0fef027d00a88e9f5bd67494d350df360f7c559fbb44e800b32f310fb989c860214eacbb561c
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -5323,6 +5484,13 @@ __metadata:
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: 10/ce617b8da36797d09c0baacb96ca8a44460452c89362d7cb8f70ca46b4158ba8bc3606912de7c818eb4a939f7f9015cef3c766ec8a0c6bfc725fdc078e39c717
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
   languageName: node
   linkType: hard
 
@@ -5572,6 +5740,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "restore-cursor@npm:5.1.0"
+  dependencies:
+    onetime: "npm:^7.0.0"
+    signal-exit: "npm:^4.1.0"
+  checksum: 10/838dd54e458d89cfbc1a923b343c1b0f170a04100b4ce1733e97531842d7b440463967e521216e8ab6c6f8e89df877acc7b7f4c18ec76e99fb9bf5a60d358d2c
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -5583,6 +5761,13 @@ __metadata:
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 10/af47851b547e8a8dc89af144fceee17b80d5beaf5e6f57ed086432d79943434ff67ca526e92275be6f54b6189f6920a24eace75c2657eed32d02c400312b21ec
+  languageName: node
+  linkType: hard
+
+"rfdc@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "rfdc@npm:1.4.1"
+  checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
   languageName: node
   linkType: hard
 
@@ -5958,7 +6143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -5982,6 +6167,26 @@ __metadata:
     mrmime: "npm:^2.0.0"
     totalist: "npm:^3.0.0"
   checksum: 10/b110ebe28eb1740772fbbfacb6c71c58d1ec8ec17a5ae2852a5418c3ef41d52d473663613de808f8a6337ec29dd446414d0d059e75bfd13fb9630d18651c99f2
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^7.1.0":
+  version: 7.1.2
+  resolution: "slice-ansi@npm:7.1.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10/75f61e1285c294b18c88521a0cdb22cdcbe9b0fd5e8e26f649be804cc43122aa7751bd960a968e3ed7f5aa7f3c67ac605c939019eae916870ec288e878b6fafb
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "slice-ansi@npm:8.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10/6a7e146852047e26dd5857b35c767e52906549c580cce0ad2287cc32f54f5a582494f674817fc9ac21b2e4ac1ddeaa85b3dee409782681b465330278890c73a8
   languageName: node
   linkType: hard
 
@@ -6081,6 +6286,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-argv@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "string-argv@npm:0.3.2"
+  checksum: 10/f9d3addf887026b4b5f997a271149e93bf71efc8692e7dc0816e8807f960b18bcb9787b45beedf0f97ff459575ee389af3f189d8b649834cac602f2e857e75af
+  languageName: node
+  linkType: hard
+
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -6100,6 +6312,27 @@ __metadata:
     emoji-regex: "npm:^9.2.2"
     strip-ansi: "npm:^7.0.1"
   checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "string-width@npm:7.2.0"
+  dependencies:
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/42f9e82f61314904a81393f6ef75b832c39f39761797250de68c041d8ba4df2ef80db49ab6cd3a292923a6f0f409b8c9980d120f7d32c820b4a8a84a2598a295
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "string-width@npm:8.2.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10/c4f62877ec08fca155e84a260eb4f58f473cfe5169bd1c1e21ffb563d8e0b7f6d705cc3d250f2ed6bb4f30ee9732ad026f54afaac77aa487e3d1dc1b1969e51b
   languageName: node
   linkType: hard
 
@@ -6207,6 +6440,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10/475f53e9c44375d6e72807284024ac5d668ee1d06010740dec0b9744f2ddf47de8d7151f80e5f6190fc8f384e802fdf9504b76a7e9020c9faee7103623338be2
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.0, strip-ansi@npm:^7.1.2":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10/96da3bc6d73cfba1218625a3d66cf7d37a69bf0920d8735b28f9eeaafcdb6c1fe8440e1ae9eb1ba0ca355dbe8702da872e105e2e939fa93e7851b3cb5dd7d316
   languageName: node
   linkType: hard
 
@@ -6340,6 +6582,13 @@ __metadata:
   version: 0.3.2
   resolution: "tinyexec@npm:0.3.2"
   checksum: 10/b9d5fed3166fb1acd1e7f9a89afcd97ccbe18b9c1af0278e429455f6976d69271ba2d21797e7c36d57d6b05025e525d2882d88c2ab435b60d1ddf2fea361de57
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "tinyexec@npm:1.1.1"
+  checksum: 10/480bbd7b0cdd73652e1a03ed82cec29cbde7d75e68094b65d289eb31578d467954d81af41f3a6de0bc805f6c22c89a36d24986a6c4c0349fa230dfb3924530a7
   languageName: node
   linkType: hard
 
@@ -6968,7 +7217,9 @@ __metadata:
     eslint: "npm:^9"
     eslint-config-next: "npm:15.3.4"
     eslint-plugin-prettier: "npm:^5.5.0"
+    husky: "npm:^9.1.7"
     jsdom: "npm:^26.1.0"
+    lint-staged: "npm:^16.4.0"
     mysql2: "npm:^3.14.1"
     nanoid: "npm:^5.1.5"
     next: "npm:15.3.4"
@@ -7001,6 +7252,17 @@ __metadata:
     string-width: "npm:^5.0.1"
     strip-ansi: "npm:^7.0.1"
   checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "wrap-ansi@npm:9.0.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/f3907e1ea9717404ca53a338fa5a017c2121550c3a5305180e2bc08c03e21aa45068df55b0d7676bf57be1880ba51a84458c17241ebedea485fafa9ef16b4024
   languageName: node
   linkType: hard
 
@@ -7051,6 +7313,15 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10/1884d272d485845ad04759a255c71775db0fac56308764b4c77ea56a20d56679fad340213054c8c9c9c26fcfd4c4b2a90df993b7e0aaf3cdb73c618d1d1a802a
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.2":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/ecad41d39d34fae5cc17ea2d4b7f7f55faacd45cbce8983ba22d48d1ed1a92ed242ea49ea813a79ac39a69f75f9c5a03e7b5395fd954d55476f25e21a47c141d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Three quality-gate improvements that work together: zero typecheck errors, a fast pre-commit hook, and a CI workflow that mirrors it.

## Commits

### 1. `fix(types): eliminate the 30 pre-existing typecheck errors`

Two root causes, both pre-existing on `main`:

- **`src/utils/parse-inline-html.ts`** — `createBlockWithInlineContent` had no return-type annotation, so TS widened its `_type: 'block'` literal to `string` and the resulting object failed to assign to `MigrationTextBlock` at every callsite (3 errors in `html-to-portable-text.ts`). Fix: add an explicit `: MigrationTextBlock` return type.
- **`src/utils/__tests__/formatting-preservation.test.ts` (27 errors)** — tests accessed `.children` / `.style` / `.listItem` directly on `MigrationBlockContent[number]`, a union that can't be narrowed without a `_type === 'block'` guard. Fix: a small `asTextBlock(block)` helper at the top of the file that throws when given a non-text block, and route every text-block expectation through it.

After this commit `yarn typecheck` exits 0 with no errors. No behaviour change; all 73 tests still pass.

### 2. `chore: add husky + lint-staged pre-commit hook`

Run quality gates locally before each commit so problems are caught before they reach a PR or CI.

`.husky/pre-commit` runs three steps in order, fast first:

1. **`yarn lint-staged`** — `prettier --write` on every staged file, plus `eslint --fix --max-warnings=0` on staged JS/TS/MJS/CJS.
2. **`yarn typecheck`** — whole-project `tsc --noEmit` (now exits clean).
3. **`yarn test:run`** — full vitest suite (~500 ms on this project).

The `lint-staged` configuration lives in `package.json` under the `lint-staged` key. Husky is enabled by the standard `prepare: husky` npm script which auto-runs after `yarn install`.

Both pre-commit invocations during the development of this PR (commits 2 and 3) successfully ran the hook end-to-end — meta-validation included.

### 3. `ci: add GitHub Actions workflow running format, lint, typecheck and tests`

`.github/workflows/ci.yml` runs on every push and pull-request to `main`. Mirrors the local pre-commit hook but in a clean CI environment so nothing slips past `lint-staged` (someone could `--no-verify` past it locally).

Steps, each failing the build on non-zero exit:

| Step | Command |
|---|---|
| Format check | `prettier --check .` |
| Lint | `yarn lint` |
| Typecheck | `yarn typecheck` |
| Tests | `yarn test:run` |

Environment:
- Node **22.16.0**, pinned to match `volta.node` in `package.json`.
- Yarn **4.9.2** via Corepack, pinned via the `packageManager` field.
- `yarn install --immutable` so a stale or modified `yarn.lock` fails.
- `.yarn/cache` cached across runs, keyed on `yarn.lock` hash.
- Concurrency: in-progress runs for the same ref are cancelled when a new commit lands.

Also includes a single-line prettier reflow of `README.md` — it had drifted from the prettier rules on `main` and would otherwise fail the new format-check step. No content change.

## Verification

- `yarn typecheck` — **0 errors** (was 30 on main) ✅
- `yarn test:run` — 73 tests pass ✅
- `yarn lint` — clean ✅
- `yarn prettier --check .` — clean ✅
- Pre-commit hook fired automatically on commits 2 and 3 of this branch and passed end-to-end ✅
