### PR TITLE
fix(dashboard): never auto-complete Import to Sanity from prerequisites

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,16 +54,7 @@ export default function Home() {
         // ignore — leave step un-marked
       }
 
-      // Step 3: Sanity prerequisites all met
-      try {
-        const r = await fetch('/api/check-sanity-prerequisites')
-        if (!cancelled && r.ok) {
-          const data = (await r.json()) as { allOk?: boolean }
-          if (data.allOk) markIfNot(3)
-        }
-      } catch {
-        // ignore
-      }
+      // Step 3 (Import to Sanity) is intentionally never auto-completed.
     }
 
     detect()


### PR DESCRIPTION
Follow-up to #9.

Meeting the Sanity prerequisites just means you *can* import \u2014 it doesn't mean you *have* imported. The previous auto-detection lit step 4 green as soon as the prereqs passed, which was misleading.

This PR removes the prereqs-based auto-completion. Step 4 is now only marked complete after an actual successful import (the existing `onComplete` callback in `ImportToSanityUI` is preserved).

Step 1 (Docker Management) auto-detection from #9 is unchanged \u2014 the container actually running *is* the whole step.