### PR TITLE
fix(dashboard): unmark Docker Management when container is torn down

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,25 +33,16 @@ export default function Home() {
   useEffect(() => {
     let cancelled = false
 
-    const markIfNot = (stepIndex: number) => {
-      setCompletedSteps((prev) => {
-        if (prev.has(stepIndex)) return prev
-        const next = new Set(prev)
-        next.add(stepIndex)
-        return next
-      })
-    }
-
     const detect = async () => {
-      // Step 0: Docker container running
+      // Step 0: Docker container running (bidirectional — unmarks if torn down)
       try {
         const r = await fetch('/api/docker/container-running')
         if (!cancelled && r.ok) {
           const data = (await r.json()) as { running?: boolean }
-          if (data.running) markIfNot(0)
+          setStepCompletion(0, !!data.running)
         }
       } catch {
-        // ignore — leave step un-marked
+        // ignore — leave step state unchanged
       }
 
       // Step 3 (Import to Sanity) is intentionally never auto-completed.
@@ -68,6 +59,16 @@ export default function Home() {
 
   const markStepCompleted = (stepIndex: number) => {
     setCompletedSteps((prev) => new Set(prev).add(stepIndex))
+  }
+
+  const setStepCompletion = (stepIndex: number, completed: boolean) => {
+    setCompletedSteps((prev) => {
+      if (prev.has(stepIndex) === completed) return prev
+      const next = new Set(prev)
+      if (completed) next.add(stepIndex)
+      else next.delete(stepIndex)
+      return next
+    })
   }
 
   const resetProgress = () => {
@@ -141,7 +142,10 @@ export default function Home() {
             </div>
           </div>
         ) : step === 0 ? (
-          <DockerManagerUI onComplete={() => markStepCompleted(0)} />
+          <DockerManagerUI
+            onComplete={() => markStepCompleted(0)}
+            onIncomplete={() => setStepCompletion(0, false)}
+          />
         ) : step === 1 ? (
           <PrepareMigrationUI onComplete={() => markStepCompleted(1)} />
         ) : step === 2 ? (

--- a/src/components/DockerManagerUI.tsx
+++ b/src/components/DockerManagerUI.tsx
@@ -13,9 +13,10 @@ interface DockerStep {
 
 interface DockerManagerUIProps {
   onComplete?: () => void
+  onIncomplete?: () => void
 }
 
-export const DockerManagerUI: React.FC<DockerManagerUIProps> = ({ onComplete }) => {
+export const DockerManagerUI: React.FC<DockerManagerUIProps> = ({ onComplete, onIncomplete }) => {
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -104,15 +105,15 @@ export const DockerManagerUI: React.FC<DockerManagerUIProps> = ({ onComplete }) 
                   })
                 } else if (data.type === 'result') {
                   setResult(data.result.message || null)
-                  // Final result - ensure all steps are updated (no need to add more)
 
-                  // Call onComplete if operation was successful and container is running
                   if (
                     operation === 'start' &&
                     data.result.message?.includes('running') &&
                     onComplete
                   ) {
                     onComplete()
+                  } else if (operation === 'stop') {
+                    onIncomplete?.()
                   }
                 } else if (data.type === 'error') {
                   // Handle streaming error - extract the error details


### PR DESCRIPTION
Tearing down the MariaDB container should remove the green checkmark from step 1. Previously the auto-detection only ever *added* completions \u2014 stopping the container left the step misleadingly green until the user manually reset progress.

## Changes

- `page.tsx`: new `setStepCompletion(stepIndex, completed)` helper. The Docker auto-detection now uses it bidirectionally, so an external `docker stop` is reflected on next mount/focus.
- `DockerManagerUI`: new `onIncomplete` prop fired after a successful **Stop Container** operation, so the nav updates immediately without waiting for a focus event.