### PR TITLE
feat(import): add 'dataset exists' check and move prereqs to top

### DIFF
--- a/src/app/api/check-sanity-prerequisites/route.ts
+++ b/src/app/api/check-sanity-prerequisites/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@sanity/client'
 
 export interface PrerequisiteCheck {
-  id: 'projectId' | 'writeToken' | 'postSchema'
+  id: 'projectId' | 'datasetExists' | 'writeToken' | 'postSchema'
   label: string
   ok: boolean
   detail?: string
@@ -33,6 +33,12 @@ export async function GET() {
 
   if (!projectId || !token) {
     checks.push({
+      id: 'datasetExists',
+      label: `Dataset '${dataset}' exists`,
+      ok: false,
+      detail: 'Cannot verify without project ID and write token',
+    })
+    checks.push({
       id: 'writeToken',
       label: 'SANITY_API_WRITE_TOKEN with write permissions',
       ok: false,
@@ -44,17 +50,69 @@ export async function GET() {
       ok: false,
       detail: 'Cannot verify without project ID and write token',
     })
-    return NextResponse.json({ checks, allOk: false } satisfies PrerequisitesResponse, {
-      headers: { 'Cache-Control': 'no-store' },
+    return json({ checks, allOk: false })
+  }
+
+  // 2. Dataset exists in the project
+  let datasetOk = false
+  try {
+    const r = await fetch(`https://api.sanity.io/v${apiVersion}/projects/${projectId}/datasets`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+    if (r.ok) {
+      const datasets = (await r.json()) as Array<{ name: string }>
+      const names = datasets.map((d) => d.name)
+      if (names.includes(dataset)) {
+        datasetOk = true
+        checks.push({
+          id: 'datasetExists',
+          label: `Dataset '${dataset}' exists`,
+          ok: true,
+          detail: `${datasets.length} dataset${datasets.length === 1 ? '' : 's'} on project: ${names.join(', ')}`,
+        })
+      } else {
+        checks.push({
+          id: 'datasetExists',
+          label: `Dataset '${dataset}' exists`,
+          ok: false,
+          detail: `Project has ${datasets.length} dataset${datasets.length === 1 ? '' : 's'} (${names.join(', ') || 'none'}), but not '${dataset}'`,
+        })
+      }
+    } else if (r.status === 401 || r.status === 403) {
+      checks.push({
+        id: 'datasetExists',
+        label: `Dataset '${dataset}' exists`,
+        ok: false,
+        detail: `Token cannot list datasets (HTTP ${r.status}) — verify the token belongs to project ${projectId}`,
+      })
+    } else if (r.status === 404) {
+      checks.push({
+        id: 'datasetExists',
+        label: `Dataset '${dataset}' exists`,
+        ok: false,
+        detail: `Project '${projectId}' not found (HTTP 404)`,
+      })
+    } else {
+      checks.push({
+        id: 'datasetExists',
+        label: `Dataset '${dataset}' exists`,
+        ok: false,
+        detail: `Datasets endpoint returned HTTP ${r.status}`,
+      })
+    }
+  } catch (error) {
+    checks.push({
+      id: 'datasetExists',
+      label: `Dataset '${dataset}' exists`,
+      ok: false,
+      detail: `Failed to reach Sanity: ${error instanceof Error ? error.message : String(error)}`,
     })
   }
 
   const client = createClient({ projectId, dataset, token, apiVersion, useCdn: false })
 
-  // 2. SANITY_API_WRITE_TOKEN with write permissions
-  // Verified by performing a dry-run mutation. Sanity returns auth errors before
-  // executing the (no-op) mutation, so this is a safe way to verify write access
-  // without touching the dataset.
+  // 3. SANITY_API_WRITE_TOKEN with write permissions — dry-run mutation
   let writeOk = false
   let writeDetail = ''
   try {
@@ -80,14 +138,8 @@ export async function GET() {
     detail: writeDetail,
   })
 
-  // 3. Sanity project has a 'post' schema
-  // The Content Lake API is schemaless, so we can't ask "does the schema have a
-  // post type?" directly without studio-level auth. Instead we look at what's
-  // already in the dataset:
-  //   - 'post' documents exist  → schema in use, ✅
-  //   - dataset is empty        → can't verify, give benefit of the doubt, ✅
-  //   - other types but no post → likely missing post type, ❌
-  if (writeOk) {
+  // 4. 'post' schema in use — content heuristic (Content Lake is schemaless)
+  if (writeOk && datasetOk) {
     try {
       const [postCount, otherCount] = (await client.fetch(
         '[count(*[_type == "post"]), count(*[!(_type match "sanity.*") && _type != "post"])]',
@@ -129,12 +181,15 @@ export async function GET() {
       id: 'postSchema',
       label: "Sanity project has a 'post' schema",
       ok: false,
-      detail: 'Cannot verify without a working write token',
+      detail: !datasetOk
+        ? 'Cannot verify without a valid dataset'
+        : 'Cannot verify without a working write token',
     })
   }
 
-  return NextResponse.json(
-    { checks, allOk: checks.every((c) => c.ok) } satisfies PrerequisitesResponse,
-    { headers: { 'Cache-Control': 'no-store' } },
-  )
+  return json({ checks, allOk: checks.every((c) => c.ok) })
+}
+
+function json(body: PrerequisitesResponse) {
+  return NextResponse.json(body, { headers: { 'Cache-Control': 'no-store' } })
 }

--- a/src/components/ImportToSanityUI.tsx
+++ b/src/components/ImportToSanityUI.tsx
@@ -257,6 +257,63 @@ export const ImportToSanityUI: React.FC<ImportToSanityUIProps> = ({ onComplete }
     <div className="p-8">
       <h2 className="text-2xl font-bold mb-6 text-gray-100">Import to Sanity</h2>
 
+      {/* Prerequisites Check (auto-detected) */}
+      {(() => {
+        const allOk = prereqs?.allOk === true
+        const boxClass = prereqsLoading
+          ? 'bg-gray-800 border-gray-600/50'
+          : allOk
+            ? 'bg-green-900/30 border-green-600/50'
+            : 'bg-yellow-900/30 border-yellow-600/50'
+        const headingClass = prereqsLoading
+          ? 'text-gray-300'
+          : allOk
+            ? 'text-green-300'
+            : 'text-yellow-300'
+        const headingText = prereqsLoading
+          ? '⏳ Checking prerequisites…'
+          : allOk
+            ? '✅ All prerequisites met'
+            : '⚠️ Prerequisites'
+
+        return (
+          <div className={`${boxClass} border rounded-lg p-4 mb-6`}>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className={`text-sm font-semibold ${headingClass}`}>{headingText}</h4>
+              {!prereqsLoading && (
+                <button
+                  onClick={checkPrerequisites}
+                  className="text-xs text-gray-400 hover:text-gray-200 underline"
+                >
+                  Re-check
+                </button>
+              )}
+            </div>
+            <ul className="text-sm space-y-1">
+              {(prereqs?.checks ?? []).map((check) => (
+                <li key={check.id} className="flex items-start gap-2">
+                  <span
+                    className={`mt-0.5 flex-shrink-0 ${
+                      check.ok ? 'text-green-400' : 'text-red-400'
+                    }`}
+                    aria-label={check.ok ? 'pass' : 'fail'}
+                  >
+                    {check.ok ? '✅' : '❌'}
+                  </span>
+                  <div className="flex-1">
+                    <p className={check.ok ? 'text-green-200' : 'text-yellow-200'}>{check.label}</p>
+                    {check.detail && <p className="text-xs text-gray-400 mt-0.5">{check.detail}</p>}
+                  </div>
+                </li>
+              ))}
+              {prereqsLoading && !prereqs && (
+                <li className="text-gray-400">Detecting environment…</li>
+              )}
+            </ul>
+          </div>
+        )
+      })()}
+
       {/* Configuration Section */}
       <div className="bg-gray-800 rounded-lg p-6 mb-6 border border-gray-700">
         <h3 className="text-lg font-semibold mb-4 text-gray-100">Import Configuration</h3>
@@ -404,63 +461,6 @@ export const ImportToSanityUI: React.FC<ImportToSanityUIProps> = ({ onComplete }
           </div>
         </div>
       </div>
-
-      {/* Prerequisites Check (auto-detected) */}
-      {(() => {
-        const allOk = prereqs?.allOk === true
-        const boxClass = prereqsLoading
-          ? 'bg-gray-800 border-gray-600/50'
-          : allOk
-            ? 'bg-green-900/30 border-green-600/50'
-            : 'bg-yellow-900/30 border-yellow-600/50'
-        const headingClass = prereqsLoading
-          ? 'text-gray-300'
-          : allOk
-            ? 'text-green-300'
-            : 'text-yellow-300'
-        const headingText = prereqsLoading
-          ? '⏳ Checking prerequisites…'
-          : allOk
-            ? '✅ All prerequisites met'
-            : '⚠️ Prerequisites'
-
-        return (
-          <div className={`${boxClass} border rounded-lg p-4 mb-6`}>
-            <div className="flex items-center justify-between mb-2">
-              <h4 className={`text-sm font-semibold ${headingClass}`}>{headingText}</h4>
-              {!prereqsLoading && (
-                <button
-                  onClick={checkPrerequisites}
-                  className="text-xs text-gray-400 hover:text-gray-200 underline"
-                >
-                  Re-check
-                </button>
-              )}
-            </div>
-            <ul className="text-sm space-y-1">
-              {(prereqs?.checks ?? []).map((check) => (
-                <li key={check.id} className="flex items-start gap-2">
-                  <span
-                    className={`mt-0.5 flex-shrink-0 ${
-                      check.ok ? 'text-green-400' : 'text-red-400'
-                    }`}
-                    aria-label={check.ok ? 'pass' : 'fail'}
-                  >
-                    {check.ok ? '✅' : '❌'}
-                  </span>
-                  <div className="flex-1">
-                    <p className={check.ok ? 'text-green-200' : 'text-yellow-200'}>{check.label}</p>
-                    {check.detail && <p className="text-xs text-gray-400 mt-0.5">{check.detail}</p>}
-                  </div>
-                </li>
-              ))}
-              {prereqsLoading && !prereqs && (
-                <li className="text-gray-400">Detecting environment…</li>
-              )}
-            </ul>
-          </div>
-        )
-      })()}
 
       {/* Import Button */}
       <button


### PR DESCRIPTION
Two small polish items for the Import to Sanity step:

## 1. New `datasetExists` check

Hits `GET https://api.sanity.io/v<v>/projects/<id>/datasets` and verifies the configured `NEXT_PUBLIC_SANITY_DATASET` is present in the returned list. Catches:
- Wrong project ID (`HTTP 404`)
- Token from a different project (`HTTP 401/403`)
- Typo'd dataset name (`Project has 1 dataset (production), but not 'productionn'`)

Without this, a missing dataset surfaces as a confusing token error from the dry-run mutation. Now you get a precise message up front.

## 2. Prerequisites panel moves above Import Configuration

Reading order: see what needs to be true \u2192 then configure the import. Less back-and-forth.

## Verified

```json
{
  "allOk": true,
  "checks": [
    { "id": "projectId",     "ok": true, "detail": "Project: o98l2fej \u00b7 Dataset: production" },
    { "id": "datasetExists", "ok": true, "detail": "1 dataset on project: production" },
    { "id": "writeToken",    "ok": true, "detail": "Token accepted by Sanity (dry-run mutation succeeded)" },
    { "id": "postSchema",    "ok": true, "detail": "3 existing 'post' documents in dataset" }
  ]
}
```